### PR TITLE
Auctipus: Add support for shift-clicking from the craft UI.

### DIFF
--- a/Auctipus.lua
+++ b/Auctipus.lua
@@ -32,6 +32,9 @@ function Auctipus.AddOn.ADDON_LOADED(addOnName)
         AUCTIPUS_INCOMPATIBLE[addOnName] = nil
     end
     if addOnName ~= "Auctipus" then
+        if addOnName == "Blizzard_CraftUI" then
+            AuctipusFrame.BrowseFrame:OnCraftUILoad()
+        end
         return
     end
 
@@ -77,6 +80,11 @@ function Auctipus.AddOn.ADDON_LOADED(addOnName)
 
     -- Make it so that the frame will close when we hit Escape.
     table.insert(UISpecialFrames, AuctipusFrame:GetName())
+
+    -- And fix the stupid craft frame.
+    if IsAddOnLoaded("Blizzard_CraftUI") then
+        AuctipusFrame.BrowseFrame:OnCraftUILoad()
+    end
 end
 
 function Auctipus.AddOn.AUCTION_HOUSE_SHOW()

--- a/AuctipusBrowseFrame.lua
+++ b/AuctipusBrowseFrame.lua
@@ -269,6 +269,13 @@ function AuctipusBrowseFrame:OnLoad()
     self:SetScript("OnHide", function() self:OnHide() end)
 end
 
+function AuctipusBrowseFrame:OnCraftUILoad()
+    for i=1, 8 do
+        _G["CraftReagent"..i]:HookScript("OnClick",
+            function(f) self:OnCraftItemTemplateClick(f, i) end)
+    end
+end
+
 function AuctipusBrowseFrame:ToggleDropDown(dd)
     local dds = {self.RarityDropDownMenu,
                  self.CategoryDropDown,
@@ -330,6 +337,15 @@ function AuctipusBrowseFrame:OnContainerModifiedClick(f)
     if self:IsVisible() then
         StackSplitFrame:Hide()
     end
+end
+
+function AuctipusBrowseFrame:OnCraftItemTemplateClick(f, index)
+    if not self:IsVisible() or not IsShiftKeyDown() then
+        return
+    end
+
+    local link = GetCraftReagentItemLink(GetCraftSelectionIndex(), index)
+    self:OnChatEdit_InsertLink(link)
 end
 
 function AuctipusBrowseFrame:OnRarityDropDownClick(index, selected)


### PR DESCRIPTION
The tradeskill UI (such as tailoring) is different from the craft UI (such as enchanting), even though they look mostly the same.  The craft UI doesn't have the "create all" button or edit field to select the number of items to craft at once.  It also isn't as easily-hookable as the tradeskill UI; we hook the UI's reagent button frames directly here.